### PR TITLE
Use JS player toggle and tmi.js chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+tsconfig.tsbuildinfo

--- a/app/watch/[channel]/page.tsx
+++ b/app/watch/[channel]/page.tsx
@@ -1,23 +1,21 @@
 import type { Metadata } from "next";
+import WatchPlayer from "@/components/WatchPlayer";
+import TwitchChat from "@/components/TwitchChat";
 
 export const dynamic = "force-dynamic";
 
 export async function generateMetadata({ params }: { params: { channel: string } }): Promise<Metadata> {
-  return { title: `${params.channel} • Watch` };
+  return { title: `${params.channel} \u2022 Watch` };
 }
 
 export default async function Watch({ params }: { params: { channel: string } }) {
   const parent = process.env.NEXT_PUBLIC_TWITCH_PARENT || "localhost";
   const { channel } = params;
-  const playerSrc = `https://player.twitch.tv/?channel=${encodeURIComponent(channel)}&parent=${encodeURIComponent(parent)}&muted=false&autoplay=true`;
-  const chatSrc = `https://www.twitch.tv/embed/${encodeURIComponent(channel)}/chat?parent=${encodeURIComponent(parent)}`;
 
   return (
     <div className="grid gap-4 lg:grid-cols-3">
       <div className="lg:col-span-2">
-        <div className="aspect-video overflow-hidden rounded-xl border border-white/5 bg-black">
-          <iframe src={playerSrc} allowFullScreen scrolling="no" className="h-full w-full" />
-        </div>
+        <WatchPlayer channel={channel} parent={parent} />
         <div className="mt-4 rounded-xl bg-surface p-4">
           <h2 className="font-semibold">About this stream</h2>
           <p className="mt-2 text-sm text-text-muted">Basic watch page. Tabs for Info / VODs / Clips can be added later.</p>
@@ -25,9 +23,10 @@ export default async function Watch({ params }: { params: { channel: string } })
       </div>
       <aside className="rounded-xl border border-white/5 bg-surface">
         <div className="h-[70vh]">
-          <iframe src={chatSrc} scrolling="no" className="h-full w-full rounded-xl" />
+          <TwitchChat channel={channel} />
         </div>
       </aside>
     </div>
   );
 }
+

--- a/components/TwitchChat.tsx
+++ b/components/TwitchChat.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Msg = { id: string; user: string; text: string };
+
+export default function TwitchChat({ channel }: { channel: string }) {
+  const [messages, setMessages] = useState<Msg[]>([]);
+
+  useEffect(() => {
+    let client: any;
+    function init() {
+      const tmi = (window as any).tmi;
+      if (!tmi) return;
+      client = new tmi.Client({ channels: [channel] });
+      client.connect();
+      client.on("message", (_: string, tags: any, msg: string, self: boolean) => {
+        if (self) return;
+        setMessages((m) => [
+          ...m.slice(-100),
+          { id: tags.id || Date.now().toString(), user: tags["display-name"] || tags.username || "", text: msg },
+        ]);
+      });
+    }
+    if (!(window as any).tmi) {
+      const s = document.createElement("script");
+      s.src = "https://unpkg.com/tmi.js@1.8.5/dist/tmi.min.js";
+      s.onload = init;
+      document.body.appendChild(s);
+    } else {
+      init();
+    }
+    return () => {
+      client?.disconnect();
+    };
+  }, [channel]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto p-2 text-sm space-y-1">
+        {messages.map((m) => (
+          <div key={m.id}>
+            <span className="font-semibold">{m.user}: </span>
+            <span>{m.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/components/WatchPlayer.tsx
+++ b/components/WatchPlayer.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export default function WatchPlayer({ channel, parent }: { channel: string; parent: string }) {
+  const [useIframe, setUseIframe] = useState(false);
+  const [muted, setMuted] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const playerRef = useRef<any>(null);
+
+  useEffect(() => {
+    if (useIframe) return;
+    function createPlayer() {
+      if (playerRef.current) playerRef.current.destroy();
+      const Twitch = (window as any).Twitch;
+      if (!containerRef.current || !Twitch) return;
+      playerRef.current = new Twitch.Player(containerRef.current, {
+        channel,
+        parent: [parent],
+        autoplay: true,
+      });
+      playerRef.current.setMuted(muted);
+    }
+    if (!(window as any).Twitch) {
+      const script = document.createElement("script");
+      script.src = "https://player.twitch.tv/js/embed/v1.js";
+      script.onload = createPlayer;
+      document.body.appendChild(script);
+    } else {
+      createPlayer();
+    }
+    return () => {
+      playerRef.current?.destroy();
+      playerRef.current = null;
+    };
+  }, [channel, parent, useIframe, muted]);
+
+  useEffect(() => {
+    if (!useIframe && playerRef.current) {
+      playerRef.current.setMuted(muted);
+    }
+  }, [muted, useIframe]);
+
+  const iframeSrc = `https://player.twitch.tv/?channel=${encodeURIComponent(channel)}&parent=${encodeURIComponent(parent)}&muted=false&autoplay=true`;
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end gap-2">
+        {!useIframe && (
+          <button
+            onClick={() => setMuted((m) => !m)}
+            className="rounded bg-surface px-2 py-1 text-sm"
+          >
+            {muted ? "Unmute" : "Mute"}
+          </button>
+        )}
+        <button
+          onClick={() => setUseIframe((v) => !v)}
+          className="rounded bg-surface px-2 py-1 text-sm"
+        >
+          Switch to {useIframe ? "JS" : "iframe"} player
+        </button>
+      </div>
+      <div className="aspect-video overflow-hidden rounded-xl border border-white/5 bg-black">
+        {useIframe ? (
+          <iframe src={iframeSrc} allowFullScreen scrolling="no" className="h-full w-full" />
+        ) : (
+          <div ref={containerRef} className="h-full w-full" />
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Replace Twitch iframes with a JS embed player that can toggle back to the iframe and provides a mute control
- Swap embedded chat iframe for a tmi.js-powered read-only chat client
- Add ignore rules for node_modules and build artifacts

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_68a837142ee48320bf9ef3e7f0eb0da7