### PR TITLE
fix type errors for tmi.js

### DIFF
--- a/lib/twitch/chat.ts
+++ b/lib/twitch/chat.ts
@@ -1,7 +1,7 @@
-import tmi from "tmi.js";
+import tmi, { Options } from "tmi.js";
 
 export function connectChat({ channel, username, oauth }: { channel: string; username?: string; oauth?: string }) {
-  const opts: tmi.Options = {
+  const opts: Options = {
     connection: { secure: true, reconnect: true },
     channels: [channel],
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,9 +17,28 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "paths": { "@/*": ["./*"] },
-    "types": ["node"]
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    },
+    "types": [
+      "node"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/types/tmi.d.ts
+++ b/types/tmi.d.ts
@@ -1,0 +1,28 @@
+declare module 'tmi.js' {
+  export interface Options {
+    identity?: {
+      username: string;
+      password: string;
+    };
+    channels: string[];
+    connection?: {
+      secure?: boolean;
+      reconnect?: boolean;
+    };
+    [key: string]: any;
+  }
+
+  export class Client {
+    constructor(opts: Options);
+    connect(): void;
+    disconnect(): void;
+    on(event: string, listener: (...args: any[]) => void): void;
+    say(channel: string, message: string): void;
+  }
+
+  const tmi: {
+    Client: typeof Client;
+  };
+
+  export default tmi;
+}


### PR DESCRIPTION
## Summary
- add minimal TypeScript declarations for `tmi.js`
- import `Options` type and use typed client in Twitch chat connection
- include declaration files in TypeScript configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck`
- `npm run build` *(fails: fetch failed during prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12da976483208711d17f3f79809d