### PR TITLE
Add tmi.js type stub and lint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/lib/twitch/chat.ts
+++ b/lib/twitch/chat.ts
@@ -1,7 +1,13 @@
 import tmi from "tmi.js";
 
+interface TmiOptions {
+  connection?: { secure?: boolean; reconnect?: boolean };
+  channels: string[];
+  identity?: { username: string; password: string };
+}
+
 export function connectChat({ channel, username, oauth }: { channel: string; username?: string; oauth?: string }) {
-  const opts: tmi.Options = {
+  const opts: TmiOptions = {
     connection: { secure: true, reconnect: true },
     channels: [channel],
   };

--- a/types/tmi-js.d.ts
+++ b/types/tmi-js.d.ts
@@ -1,0 +1,13 @@
+declare module 'tmi.js' {
+  export class Client {
+    constructor(options: any);
+    connect(): Promise<any>;
+    disconnect(): Promise<any>;
+    say(channel: string, message: string): Promise<any>;
+    on(event: string, handler: (...args: any[]) => void): void;
+  }
+  const tmi: {
+    Client: typeof Client;
+  };
+  export default tmi;
+}


### PR DESCRIPTION
## Summary
- provide minimal TypeScript declarations for tmi.js
- define chat options locally instead of relying on missing types
- add Next.js ESLint config

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: 5 warnings)*
- `npm run build` *(fails: fetch failed during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68ae14d6ec048320a338b4332ef58050